### PR TITLE
macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(hdmx examples/Hdmx/main.c)
 target_link_libraries(hdmx PUBLIC HueEnt)
 
 # Example: HueVis
+IF(NOT CMAKE_HOST_APPLE)
 add_executable(huevis examples/HueVis/huevis.c examples/HueVis/input_pulse.c examples/HueVis/input_squeezelite.c examples/HueVis/process_cava.c)
 target_link_libraries(huevis PUBLIC HueEnt)
 find_package (Threads)
@@ -46,6 +47,7 @@ target_link_libraries(huevis PUBLIC rt)
 target_link_libraries(huevis PUBLIC config)
 target_link_libraries(huevis PUBLIC pulse)
 target_link_libraries(huevis PUBLIC pulse-simple)
+ENDIF(NOT CMAKE_HOST_APPLE)
 
 # Example: Hutil
 add_executable(hutil examples/Hutil/main.c)

--- a/examples/Hdmx/main.c
+++ b/examples/Hdmx/main.c
@@ -116,9 +116,14 @@ void sendPollReply(struct sockaddr_in *sender,int artnetSock)
     buffer[210]=buffer[13];
 
 
+    int flags = 0;
+
+#ifdef MSG_CONFIRM
+    flags = MSG_CONFIRM;
+#endif
 
     int n=sendto(artnetSock, buffer, 240, 
-        MSG_CONFIRM, (const struct sockaddr *) &servaddr,  
+        flags, (const struct sockaddr *) &servaddr,
             sizeof(servaddr)); 
     if(n==-1)
 	{

--- a/include/dtls.h
+++ b/include/dtls.h
@@ -17,6 +17,7 @@
 #include <openssl/ssl.h>
 #include <openssl/conf.h>
 #include <openssl/engine.h>
+#include <openssl/opensslv.h>
 #include <math.h>
 #include <ctype.h>
 #include "debug.h"

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -234,8 +234,8 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
     return -1;
   }
 
-  ctx->ssl_ctx = SSL_CTX_new(DTLSv1_2_client_method());
-
+  ctx->ssl_ctx = SSL_CTX_new(DTLS_client_method());
+  SSL_CTX_set_min_proto_version(ctx->ssl_ctx, DTLS1_2_VERSION);
   SSL_CTX_set_psk_client_callback(ctx->ssl_ctx, psk_cb);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -238,7 +238,9 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
 
   SSL_CTX_set_psk_client_callback(ctx->ssl_ctx, psk_cb);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
   SSL_CTX_set_ciphersuites(ctx->ssl_ctx, "TLS_PSK_WITH_AES_128_GCM_SHA256");
+#endif
 
 #ifdef __APPLE__
   SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_QUERY_MTU);


### PR DESCRIPTION
I ran into an issue on macOS where OpenSSL 1.1.1 (from homebrew) was unable to figure out the MTU and was causing packets to fragment (which prevented anything from working).

Setting the MTU allowed it to work.

I also added a couple SSL options just to ensure that it's using the cipher that Philips says is needed.