### PR TITLE
add apiversion, modify cmake & names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(HueEnt VERSION 0.0.1 LANGUAGES C)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_library(HueEnt src/hue_entertainment.c src/hue_rest.c src/dtls.c)
+add_library(HueEnt src/hue_entertainment.c src/hue_rest.c src/hue_dtls.c)
 
 # CURL
 find_package(CURL REQUIRED)
@@ -27,32 +27,44 @@ target_include_directories(HueEnt
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+OPTION(EXAMPLE_BASIC_COLOUR_FADE "Build BasicColourFade example" ON)
+OPTION(EXAMPLE_HDMX "Build Hdmx example" ON)
+OPTION(EXAMPLE_HUEVIS "Build HueVis example" ON)
+OPTION(EXAMPLE_HUTIL "Build Hutil example" ON)
+
 # Example: BasicColourFade
-add_executable(bcf examples/BasicColourFade/main.c)
-target_link_libraries(bcf PUBLIC HueEnt)
+IF(EXAMPLE_BASIC_COLOUR_FADE)
+    add_executable(bcf examples/BasicColourFade/main.c)
+    target_link_libraries(bcf PUBLIC HueEnt)
+ENDIF(EXAMPLE_BASIC_COLOUR_FADE)
 
 # Example: Hdmx
-add_executable(hdmx examples/Hdmx/main.c)
-target_link_libraries(hdmx PUBLIC HueEnt)
+IF(EXAMPLE_HDMX)
+    add_executable(hdmx examples/Hdmx/main.c)
+    target_link_libraries(hdmx PUBLIC HueEnt)
+ENDIF(EXAMPLE_HDMX)
 
 # Example: HueVis
-IF(NOT CMAKE_HOST_APPLE)
-add_executable(huevis examples/HueVis/huevis.c examples/HueVis/input_pulse.c examples/HueVis/input_squeezelite.c examples/HueVis/process_cava.c)
-target_link_libraries(huevis PUBLIC HueEnt)
-find_package (Threads)
-target_link_libraries(huevis PUBLIC ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(huevis PUBLIC fftw3)
-target_link_libraries(huevis PUBLIC m)
-target_link_libraries(huevis PUBLIC rt)
-target_link_libraries(huevis PUBLIC config)
-target_link_libraries(huevis PUBLIC pulse)
-target_link_libraries(huevis PUBLIC pulse-simple)
-ENDIF(NOT CMAKE_HOST_APPLE)
+IF(EXAMPLE_HUEVIS)
+    IF(NOT CMAKE_HOST_APPLE)
+    add_executable(huevis examples/HueVis/huevis.c examples/HueVis/input_pulse.c examples/HueVis/input_squeezelite.c examples/HueVis/process_cava.c)
+    target_link_libraries(huevis PUBLIC HueEnt)
+    find_package (Threads)
+    target_link_libraries(huevis PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(huevis PUBLIC fftw3)
+    target_link_libraries(huevis PUBLIC m)
+    target_link_libraries(huevis PUBLIC rt)
+    target_link_libraries(huevis PUBLIC config)
+    target_link_libraries(huevis PUBLIC pulse)
+    target_link_libraries(huevis PUBLIC pulse-simple)
+    ENDIF(NOT CMAKE_HOST_APPLE)
+ENDIF(EXAMPLE_HUEVIS)
 
 # Example: Hutil
-add_executable(hutil examples/Hutil/main.c)
-target_link_libraries(hutil PUBLIC HueEnt)
-target_link_libraries(hutil PUBLIC config)
-
+IF(EXAMPLE_HUTIL)
+    add_executable(hutil examples/Hutil/main.c)
+    target_link_libraries(hutil PUBLIC HueEnt)
+    target_link_libraries(hutil PUBLIC config)
+ENDIF(EXAMPLE_HUTIL)
 
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,8 +1,0 @@
-#pragma once
-
-typedef void (*debug_cb_t)(const char *message, void *user_data);
-
-#define MSG_DEBUG  3
-#define MSG_INFO   2
-#define MSG_ERR    1
-#define MSG_OFF    0

--- a/include/hue_debug.h
+++ b/include/hue_debug.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef void (*hue_debug_cb_t)(const char *message, void *user_data);
+
+#define HUE_MSG_DEBUG  3
+#define HUE_MSG_INFO   2
+#define HUE_MSG_ERR    1
+#define HUE_MSG_OFF    0

--- a/include/hue_dtls.h
+++ b/include/hue_dtls.h
@@ -20,13 +20,14 @@
 #include <openssl/opensslv.h>
 #include <math.h>
 #include <ctype.h>
-#include "debug.h"
+#include "hue_debug.h"
 
-#define DTLS_STATE_INIT      10
-#define DTLS_STATE_CONNECTED 20
-#define DTLS_STATE_CLEANEDUP 30
+#define HUE_DTLS_MAX_PAYLOAD_SIZE 1350
+#define HUE_DTLS_STATE_INIT      10
+#define HUE_DTLS_STATE_CONNECTED 20
+#define HUE_DTLS_STATE_CLEANEDUP 30
 
-struct dtls_ctx
+struct hue_dtls_ctx
 {
   SSL_CTX *ssl_ctx;
   SSL  *ssl;
@@ -40,16 +41,16 @@ struct dtls_ctx
   int  state;
   void *user_data;
   int  debug_level;
-  debug_cb_t debug_callback;
+  hue_debug_cb_t debug_callback;
 };
 
-/* Function: dtls_init
+/* Function: hue_dtls_init
 
-   Initialise a new dtls_ctx object. Be sure to call dtls_cleanup when finished with ctx.
+   Initialise a new hue_dtls_ctx object. Be sure to call dtls_cleanup when finished with ctx.
 
    Parameters:
 
-      ctx - dtls_ctx object to initialise
+      ctx - hue_dtls_ctx object to initialise
       psk_identity - Pre-shared key identity for the session
       psk_key - Pre-shared key for the session
       debug_callback - (optional) debug callback to receive debug messages. Set to NULL to print to STDOUT.
@@ -59,15 +60,15 @@ struct dtls_ctx
 
       0 on success, non-zero otherwise
 */
-int  dtls_init(struct dtls_ctx *ctx, const char *psk_identity, const char *psk_key, debug_cb_t debug_callback, int debug_level);
+int  hue_dtls_init(struct hue_dtls_ctx *ctx, const char *psk_identity, const char *psk_key, hue_debug_cb_t debug_callback, int debug_level);
 
-/* Function: dtls_connect
+/* Function: hue_dtls_connect
 
    Start dtls connection
 
    Parameters:
 
-      ctx - Initialised dtls_ctx object
+      ctx - Initialised hue_dtls_ctx object
       address - IP address to connect to
       port - port number
 
@@ -75,15 +76,15 @@ int  dtls_init(struct dtls_ctx *ctx, const char *psk_identity, const char *psk_k
 
       0 on success, non-zero otherwise
 */
-int  dtls_connect(struct dtls_ctx *ctx, const char *address, int port);
+int  hue_dtls_connect(struct hue_dtls_ctx *ctx, const char *address, int port);
 
-/* Function: dtls_send_data
+/* Function: hue_dtls_send_data
 
    Send data on connecion
 
    Parameters:
 
-      ctx - Connected dtls_ctx object
+      ctx - Connected hue_dtls_ctx object
       buf - data to send
       port - length of data to send
 
@@ -91,14 +92,14 @@ int  dtls_connect(struct dtls_ctx *ctx, const char *address, int port);
 
       0 on success, non-zero otherwise
 */
-int  dtls_send_data(struct dtls_ctx *ctx, void *buf, int length);
+int  hue_dtls_send_data(struct hue_dtls_ctx *ctx, void *buf, int length);
 
-/* Function: dtls_cleanup
+/* Function: hue_dtls_cleanup
 
    Disconnect if connected, and free any memory associated with dtls context.
 
    Parameters:
 
-      ctx - dtls_ctx object
+      ctx - hue_dtls_ctx object
 */
-void dtls_cleanup(struct dtls_ctx *ctx);
+void hue_dtls_cleanup(struct hue_dtls_ctx *ctx);

--- a/include/hue_entertainment.h
+++ b/include/hue_entertainment.h
@@ -110,5 +110,3 @@ int hue_ent_get_message(struct hue_ent_ctx *ctx, void **out_msg_buf, int *out_bu
       ctx - hue_ent_ctx object
 */
 void hue_ent_cleanup(struct hue_ent_ctx *ctx);
-
-

--- a/include/hue_rest.h
+++ b/include/hue_rest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "debug.h"
+#include "hue_debug.h"
 
 
 
@@ -13,6 +13,7 @@
 #include <stdarg.h>
 #include <json-c/json.h>
 
+#define HUE_ENTERTAINMENT_API_NEEDED "1.22.0"
 
 #define AREA_NAME_LEN       33
 #define MAX_LIGHTS_PER_AREA 10
@@ -64,7 +65,6 @@
 #define HUE_ERR_FACTORY_NEW                     802
 #define HUE_ERR_INVALID_STATE                   803
 
-
 struct hue_entertainment_area
 {
   uint16_t area_id;
@@ -83,9 +83,10 @@ struct hue_whitelist_entry
 
 struct hue_rest_ctx
 {
-  debug_cb_t debug_callback;
+  hue_debug_cb_t debug_callback;
   int  debug_level;
   void *user_data;
+  char *apiversion;
   char *username;
   char *clientkey;
   char *address;
@@ -136,7 +137,7 @@ void hue_rest_cleanup();
 
       0 on success, non-zero otherwise
 */
-int hue_rest_init_ctx(struct hue_rest_ctx *ctx, debug_cb_t debug_callback, const char *address, int port, const char *username, int debug_level);
+int hue_rest_init_ctx(struct hue_rest_ctx *ctx, hue_debug_cb_t debug_callback, const char *address, int port, const char *username, int debug_level);
 
 /* Function: hue_rest_cleanup_ctx
 
@@ -163,6 +164,9 @@ void hue_rest_cleanup_ctx(struct hue_rest_ctx *ctx);
       0 on success, non-zero otherwise
 */
 int hue_rest_activate_stream(struct hue_rest_ctx *ctx, int group);
+
+/* TODO */
+int hue_rest_delete_user(struct hue_rest_ctx *ctx, const char *username);
 
 /* Function: hue_rest_get_ent_groups
 
@@ -199,6 +203,21 @@ int hue_rest_get_whitelist(struct hue_rest_ctx *ctx, struct hue_whitelist_entry 
 /* TODO */
 int hue_rest_delete_user(struct hue_rest_ctx *ctx, const char *username);
 
+/* Function: hue_rest_validate_apiversion
+
+   Check if apiversion of bridge is compatible.
+
+   Parameters:
+   
+         ctx - hue_rest_ctx context
+
+   Returns:
+
+       -  0 apiversion of bridge is compatible
+          (equal or greater to apiversion needed)
+       -  non-zero otherwise
+*/
+int hue_rest_validate_apiversion(struct hue_rest_ctx *ctx);
 
 /* Function: hue_rest_register
 

--- a/src/hue_dtls.c
+++ b/src/hue_dtls.c
@@ -3,13 +3,13 @@
  *   https://bitbucket.org/tiebingzhang/tls-psk-server-client-example/src/783092f802383421cfa1088b0e7b804b39d3cf7c (Tiebing Zhang)
  */
 
-#include "dtls.h"
+#include "hue_dtls.h"
 
-#define MAX_PAYLOAD_SIZE 1350
+#define HUE_DTLS_MAX_PAYLOAD_SIZE 1350
 
-static int dtls_ctx_index;
+static int hue_dtls_ctx_index;
 
-static void debug(struct dtls_ctx *ctx, int level, char *fmt, ...)
+static void debug(struct hue_dtls_ctx *ctx, int level, char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -55,25 +55,25 @@ static unsigned int psk_cb(SSL *ssl, const char *hint, char *identity,
   unsigned int max_identity_len, unsigned char *psk, unsigned int max_psk_len)
 {
   int ret;
-  struct dtls_ctx *ctx;
+  struct hue_dtls_ctx *ctx;
 
-  ctx = SSL_get_ex_data(ssl, dtls_ctx_index);
+  ctx = SSL_get_ex_data(ssl, hue_dtls_ctx_index);
 
   if (!hint)
-    debug(ctx, MSG_DEBUG, "NULL received PSK identity hint, continuing anyway");
+    debug(ctx, HUE_MSG_DEBUG, "NULL received PSK identity hint, continuing anyway");
   else
-    debug(ctx, MSG_DEBUG, "Received PSK identity hint '%s'", hint);
+    debug(ctx, HUE_MSG_DEBUG, "Received PSK identity hint '%s'", hint);
 
   ret = snprintf(identity, max_identity_len, "%s", ctx->psk_identity);
   if (ret < 0 || (unsigned int)ret > max_identity_len)
   {
-    debug(ctx, MSG_ERR, "Error, psk_identify too long");
+    debug(ctx, HUE_MSG_ERR, "Error, psk_identify too long");
     return 0;
   }
 
   if (strlen(ctx->psk_key)>=(max_psk_len*2))
   {
-    debug(ctx, MSG_ERR,  "Error, psk_key too long");
+    debug(ctx, HUE_MSG_ERR,  "Error, psk_key too long");
     return 0;
   }
 
@@ -81,30 +81,30 @@ static unsigned int psk_cb(SSL *ssl, const char *hint, char *identity,
   ret = hex2bin(ctx->psk_key,psk);
   if (ret<=0)
   {
-    debug(ctx, MSG_ERR, "Error, Could not convert PSK key '%s' to binary key", ctx->psk_key);
+    debug(ctx, HUE_MSG_ERR, "Error, Could not convert PSK key '%s' to binary key", ctx->psk_key);
     return 0;
   }
   return ret;
 }
 
-int dtls_send_data(struct dtls_ctx *ctx, void *buf, int length)
+int hue_dtls_send_data(struct hue_dtls_ctx *ctx, void *buf, int length)
 {
   int len;
   int retval=0;
 
-  if (ctx->state != DTLS_STATE_CONNECTED)
+  if (ctx->state != HUE_DTLS_STATE_CONNECTED)
   {
-    debug(ctx, MSG_ERR, "dtls_send_data> dtls_ctx wrong state (%d vs expected %d)", ctx->state, DTLS_STATE_CONNECTED);
+    debug(ctx, HUE_MSG_ERR, "dtls_send_data> hue_dtls_ctx wrong state (%d vs expected %d)", ctx->state, HUE_DTLS_STATE_CONNECTED);
     return -1;
   }
 
-  debug(ctx, MSG_DEBUG, "about to write %d bytes", length);
+  debug(ctx, HUE_MSG_DEBUG, "about to write %d bytes", length);
   len = SSL_write(ctx->ssl, buf, length);
 
   switch (SSL_get_error(ctx->ssl, len))
   {
     case SSL_ERROR_NONE:
-      debug(ctx, MSG_DEBUG, "wrote %d bytes", (int) len);
+      debug(ctx, HUE_MSG_DEBUG, "wrote %d bytes", (int) len);
       break;
 
     case SSL_ERROR_WANT_WRITE:
@@ -116,19 +116,19 @@ int dtls_send_data(struct dtls_ctx *ctx, void *buf, int length)
       break;
 
     case SSL_ERROR_SYSCALL:
-      debug(ctx, MSG_ERR, "Socket write error: ");
-      debug(ctx, MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), buf), SSL_get_error(ctx->ssl, len));
+      debug(ctx, HUE_MSG_ERR, "Socket write error: ");
+      debug(ctx, HUE_MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), buf), SSL_get_error(ctx->ssl, len));
       retval = -1;
       break;
 
     case SSL_ERROR_SSL:
-      debug(ctx, MSG_ERR, "SSL write error: ");
-      debug(ctx, MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), buf), SSL_get_error(ctx->ssl, len));
+      debug(ctx, HUE_MSG_ERR, "SSL write error: ");
+      debug(ctx, HUE_MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), buf), SSL_get_error(ctx->ssl, len));
       retval = -1;
       break;
 
     default:
-      debug(ctx, MSG_ERR, "Unexpected error while writing!");
+      debug(ctx, HUE_MSG_ERR, "Unexpected error while writing!");
       retval = -1;
       break;
   }
@@ -136,21 +136,21 @@ int dtls_send_data(struct dtls_ctx *ctx, void *buf, int length)
   return retval;
 }
 
-int dtls_init(struct dtls_ctx *ctx, const char *psk_identity, const char *psk_key, debug_cb_t debug_callback, int debug_level)
+int hue_dtls_init(struct hue_dtls_ctx *ctx, const char *psk_identity, const char *psk_key, hue_debug_cb_t debug_callback, int debug_level)
 {
   static int first_run = 1;
-  memset(ctx, 0, sizeof(struct dtls_ctx));
+  memset(ctx, 0, sizeof(struct hue_dtls_ctx));
   ctx->debug_callback = debug_callback;
   ctx->debug_level = debug_level;
 
-  debug(ctx, MSG_INFO, "dtls_init() %s", first_run==1 ? "(first run)" : "");
+  debug(ctx, HUE_MSG_INFO, "hue_dtls_init() %s", first_run==1 ? "(first run)" : "");
 
   if (first_run)
   {
     first_run = 0;
     OpenSSL_add_ssl_algorithms();
     SSL_load_error_strings();
-    dtls_ctx_index = SSL_get_ex_new_index(0, "dtls_ctx index", NULL, NULL, NULL);
+    hue_dtls_ctx_index = SSL_get_ex_new_index(0, "hue_dtls_ctx index", NULL, NULL, NULL);
   }
 
   ctx->psk_identity = malloc(strlen(psk_identity)+1);
@@ -159,13 +159,13 @@ int dtls_init(struct dtls_ctx *ctx, const char *psk_identity, const char *psk_ke
   strcpy(ctx->psk_key, psk_key);
 
   ctx->fd = -1;
-  ctx->state = DTLS_STATE_INIT;
+  ctx->state = HUE_DTLS_STATE_INIT;
   return 0;
 }
 
-void dtls_cleanup(struct dtls_ctx *ctx)
+void hue_dtls_cleanup(struct hue_dtls_ctx *ctx)
 {
-  debug(ctx, MSG_INFO, "dtls_cleanup() %s");
+  debug(ctx, HUE_MSG_INFO, "dtls_cleanup() %s");
 
   if (ctx->ssl_ctx)
   {
@@ -198,21 +198,21 @@ void dtls_cleanup(struct dtls_ctx *ctx)
     ctx->fd = -1;
   }
 
-  ctx->state = DTLS_STATE_CLEANEDUP;
+  ctx->state = HUE_DTLS_STATE_CLEANEDUP;
 }
 
-int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
+int hue_dtls_connect(struct hue_dtls_ctx *ctx, const char *address, int port)
 {
   int retval;
   char err_buf[200];
 
-  if (ctx->state != DTLS_STATE_INIT)
+  if (ctx->state != HUE_DTLS_STATE_INIT)
   {
-    debug(ctx, MSG_ERR, "dtls_connect> dtls_ctx wrong state (%d vs expected %d)", ctx->state, DTLS_STATE_INIT);
+    debug(ctx, HUE_MSG_ERR, "hue_dtls_connect> hue_dtls_ctx wrong state (%d vs expected %d)", ctx->state, HUE_DTLS_STATE_INIT);
     return -1;
   }
 
-  debug(ctx, MSG_INFO, "Connecting to %s:%d", address, port);
+  debug(ctx, HUE_MSG_INFO, "Connecting to %s:%d", address, port);
 
   memset((void *) &ctx->remote_addr, 0, sizeof(struct sockaddr_in));
   memset((void *) &ctx->local_addr , 0, sizeof(struct sockaddr_in));
@@ -224,13 +224,13 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
   }
   else
   {
-    debug(ctx, MSG_ERR, "inet_pton failed");
+    debug(ctx, HUE_MSG_ERR, "inet_pton failed");
   }
 
   ctx->fd = socket(ctx->remote_addr.sin_family, SOCK_DGRAM, 0);
   if (ctx->fd < 0)
   {
-    debug(ctx, MSG_ERR, "Failed to create socket");
+    debug(ctx, HUE_MSG_ERR, "Failed to create socket");
     return -1;
   }
 
@@ -249,10 +249,10 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
   ctx->ssl = SSL_new(ctx->ssl_ctx);
 
   /* Save a reference to the dtls ctx struct so callback can access it */
-  SSL_set_ex_data(ctx->ssl, dtls_ctx_index, ctx);
+  SSL_set_ex_data(ctx->ssl, hue_dtls_ctx_index, ctx);
 
 #ifdef __APPLE__
-  SSL_set_mtu(ctx->ssl, MAX_PAYLOAD_SIZE);
+  SSL_set_mtu(ctx->ssl, HUE_DTLS_MAX_PAYLOAD_SIZE);
 #endif
 
   /* Create BIO, connect and set to already connected */
@@ -260,7 +260,7 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
   connect(ctx->fd, (struct sockaddr *) &ctx->remote_addr, sizeof(struct sockaddr_in));
   BIO_ctrl(ctx->bio, BIO_CTRL_DGRAM_SET_CONNECTED, 0, &ctx->remote_addr);
 #ifdef __APPLE__
-  BIO_ctrl(ctx->bio, BIO_CTRL_DGRAM_SET_MTU, MAX_PAYLOAD_SIZE, NULL);
+  BIO_ctrl(ctx->bio, BIO_CTRL_DGRAM_SET_MTU, HUE_DTLS_MAX_PAYLOAD_SIZE, NULL);
 #endif
   SSL_set_bio(ctx->ssl, ctx->bio, ctx->bio);
 
@@ -270,39 +270,39 @@ int dtls_connect(struct dtls_ctx *ctx, const char *address, int port)
     switch (SSL_get_error(ctx->ssl, retval)) 
     {
       case SSL_ERROR_ZERO_RETURN:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_ZERO_RETURN");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_ZERO_RETURN");
         break;
       case SSL_ERROR_WANT_READ:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_READ");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_READ");
         break;
       case SSL_ERROR_WANT_WRITE:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_WRITE");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_WRITE");
         break;
       case SSL_ERROR_WANT_CONNECT:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_CONNECT");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_CONNECT");
         break;
       case SSL_ERROR_WANT_ACCEPT:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_ACCEPT");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_ACCEPT");
         break;
       case SSL_ERROR_WANT_X509_LOOKUP:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_X509_LOOKUP");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_WANT_X509_LOOKUP");
         break;
       case SSL_ERROR_SYSCALL:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_SYSCALL");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_SYSCALL");
         break;
       case SSL_ERROR_SSL:
-        debug(ctx, MSG_ERR, "SSL_connect failed with SSL_ERROR_SSL");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with SSL_ERROR_SSL");
         break;
       default:
-        debug(ctx, MSG_ERR, "SSL_connect failed with unknown error");
+        debug(ctx, HUE_MSG_ERR, "SSL_connect failed with unknown error");
         break;
     }
-    debug(ctx, MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), err_buf), SSL_get_error(ctx->ssl, sizeof(err_buf)));
-    debug(ctx, MSG_ERR, "errno = %d (%s)", errno, strerror(errno));
+    debug(ctx, HUE_MSG_ERR, "%s (%d)", ERR_error_string(ERR_get_error(), err_buf), SSL_get_error(ctx->ssl, sizeof(err_buf)));
+    debug(ctx, HUE_MSG_ERR, "errno = %d (%s)", errno, strerror(errno));
     return -1;
   }
 
-  debug(ctx, MSG_DEBUG, "Connected; Cipher: %s", SSL_CIPHER_get_name(SSL_get_current_cipher(ctx->ssl)));
-  ctx->state = DTLS_STATE_CONNECTED;
+  debug(ctx, HUE_MSG_DEBUG, "Connected; Cipher: %s", SSL_CIPHER_get_name(SSL_get_current_cipher(ctx->ssl)));
+  ctx->state = HUE_DTLS_STATE_CONNECTED;
   return 0;
 }


### PR DESCRIPTION
This PR includes the following:
- modified CMakeLists: making the build of the examples optional (default: on)
- add a function to validate the apiversion to have a mechanism check whether compatibility is met
- make the headers and names more hue'ish. this should make name more unique. Some names were general (MSG_* --> HUE_MSG_* or debug-h --> hue_debug.h)